### PR TITLE
[BugFix]データアップロード時にアプリがクラッシュするバグを修正

### DIFF
--- a/NavigationForiOS/NavigationDataEntity.swift
+++ b/NavigationForiOS/NavigationDataEntity.swift
@@ -25,6 +25,12 @@ class NavigationDataEntity{
     var trainDataList : Array<TRAIN_DATA> = []
     var orientationDataList : Array<ORIENTATION_DATA> = []
     
+    //配列内の内容を全て削除する
+    public func resetAll(){
+        trainDataList.removeAll()
+        orientationDataList.removeAll()
+    }
+    
     /// トレーニングデータを追加する
     ///
     /// - Parameters:

--- a/NavigationForiOS/StartCreateRouteViewController.swift
+++ b/NavigationForiOS/StartCreateRouteViewController.swift
@@ -26,7 +26,6 @@ class StartRouteCreateViewController: UIViewController {
         
         //内容を全てリセットする
         appDelegate.navigationDataEntity.resetAll()
-        appDelegate.currentRouteId = 1
     }
     
     //電波強度の計測ボタンが押されたら、計測画面に遷移する

--- a/NavigationForiOS/StartCreateRouteViewController.swift
+++ b/NavigationForiOS/StartCreateRouteViewController.swift
@@ -23,6 +23,10 @@ class StartRouteCreateViewController: UIViewController {
         appDelegate.currentRouteId = 1
         //Route設定画面で指定された開始地点の名前を表示する
         startNavigationLabel.text = source + "に立ってください"
+        
+        //内容を全てリセットする
+        appDelegate.navigationDataEntity.resetAll()
+        appDelegate.currentRouteId = 1
     }
     
     //電波強度の計測ボタンが押されたら、計測画面に遷移する


### PR DESCRIPTION
# 現象
ナビゲーションデータを送信する際に，アプリが停止する事案が発生

# 条件
１回目の送信は起きないが，2回目のルートの送信時に発生

# 原因
AppDelegate内にグローバル値として持たせているルート情報が，２回目の計測の際にリセットされておらず，配列内に存在しないデータに対してアクセスをかけていたことによるオーバーランが原因と見られる

# 解決方法
データ計測開始時に，NavigationDataEntity内の配列を全てリセット

